### PR TITLE
slow_rnn has no direct input from encoder/fastrnn?

### DIFF
--- a/common/models/transducer/transducer_fullsum.py
+++ b/common/models/transducer/transducer_fullsum.py
@@ -100,8 +100,7 @@ class IDecoderSlowRnn(_IMaker):
   def make(self, *,
            prev_sparse_label_nb: LayerRef,
            prev_emit: LayerRef,
-           unmasked_sparse_label_nb_seq: Optional[LayerRef] = None,
-           prev_fast_rnn: LayerRef, encoder: LayerRef) -> LayerDict:
+           unmasked_sparse_label_nb_seq: Optional[LayerRef] = None) -> LayerDict:
     raise NotImplementedError
 
 
@@ -116,8 +115,7 @@ class DecoderSlowRnnLstmIndependent(IDecoderSlowRnn):
   def make(self, *,
            prev_sparse_label_nb: LayerRef,
            prev_emit: LayerRef,
-           unmasked_sparse_label_nb_seq: Optional[LayerRef] = None,
-           prev_fast_rnn: LayerRef, encoder: LayerRef) -> LayerDict:
+           unmasked_sparse_label_nb_seq: Optional[LayerRef] = None) -> LayerDict:
     return make_masked(
       source=prev_sparse_label_nb,
       mask=prev_emit,
@@ -239,8 +237,7 @@ class Decoder(_IMaker):
         prev_sparse_label_nb="prev_out_non_blank",
         prev_emit="prev:output_emit",
         unmasked_sparse_label_nb_seq=None if search else "lm_input",  # might enable optimization if used
-        prev_fast_rnn="prev:fast_rnn",
-        encoder="am"),
+      ),
 
       "fast_rnn": self.fast_rnn.make(
         prev_label_wb="prev:output_",


### PR DESCRIPTION
if slow_rnn doesn't make use of any data from encoder/fastrnn than we can remove the extra params.

Or are you leaving the possibility open in purpose for models like [here](https://github.com/rwth-i6/returnn-experiments/blob/master/2021-transducer-thesis-merboldt/switchboard/rna3c-lm4a.convtrain.switchout6.l2a_1e_4.nohdf.encbottle256.dec1la-n128.decdrop03.decwdrop03.pretrain_less2_rep6.mlr50.emit2.fl2.rep.fixmask.ctcalignfix-ctcalign-p0-6l.chunk60.encctc.devtrain.retrain1.config), in row 851